### PR TITLE
Update wordlg to LargeWord.word and remove Word31 references to support 64-bit SML

### DIFF
--- a/convert-word-nj.sml
+++ b/convert-word-nj.sml
@@ -3,7 +3,7 @@ structure ConvertWord : CONVERT_WORD =
    struct
 
       type word = Word.word
-      type wordlg = Word32.word
+      type wordlg = LargeWord.word
       type word8 = Word8.word
       type word31 = Word31.word
       type word32 = Word32.word
@@ -17,8 +17,8 @@ structure ConvertWord : CONVERT_WORD =
 
       fun word8ToWord31 w = Word31.fromLarge (Word8.toLarge w)
       fun word8ToWord31X w = Word31.fromLarge (Word8.toLargeX w)
-      val word8ToWord32 = Word8.toLarge
-      val word8ToWord32X = Word8.toLargeX
+      val word8ToWord32 = Word32.fromLarge o Word8.toLarge
+      val word8ToWord32X = Word32.fromLarge o Word8.toLargeX
       fun word8ToWord64 w = Word64.fromInt (Word8.toInt w)
       val word8ToIntInf = Word8.toLargeInt
 
@@ -32,8 +32,8 @@ structure ConvertWord : CONVERT_WORD =
          end
 
       fun word31ToWord8 w = Word8.fromLarge (Word31.toLarge w)
-      val word31ToWord32 = Word31.toLarge
-      val word31ToWord32X = Word31.toLargeX
+      val word31ToWord32 = Word32.fromLarge o Word31.toLarge
+      val word31ToWord32X = Word32.fromLarge o Word31.toLargeX
       val word31ToIntInf = Word31.toLargeInt
 
       fun word31ToWord64 w = 
@@ -50,8 +50,8 @@ structure ConvertWord : CONVERT_WORD =
          end
 
 
-      val word32ToWord8 = Word8.fromLarge
-      val word32ToWord31 = Word31.fromLarge
+      val word32ToWord8 = Word8.fromLarge o Word32.toLarge
+      val word32ToWord31 = Word31.fromLarge o Word32.toLarge
       fun word32ToWord64 w = Word64.fromLargeInt (Word32.toLargeInt w)
       val word32ToIntInf = Word32.toLargeInt
 
@@ -80,7 +80,7 @@ structure ConvertWord : CONVERT_WORD =
          let
             val a = Word8Array.array (4, 0w0)
          in
-            PackWord32Big.update (a, 0, w);
+            PackWord32Big.update (a, 0, Word32.toLargeWord w);
             Bytestring.fromWord8Vector (Word8Array.vector a)
          end
 
@@ -88,7 +88,7 @@ structure ConvertWord : CONVERT_WORD =
          let
             val a = Word8Array.array (4, 0w0)
          in
-            PackWord32Little.update (a, 0, w);
+            PackWord32Little.update (a, 0, Word32.toLargeWord w);
             Bytestring.fromWord8Vector (Word8Array.vector a)
          end
 
@@ -102,8 +102,8 @@ structure ConvertWord : CONVERT_WORD =
          let
             val a = Word8Array.array (8, 0w0)
          in
-            PackWord32Big.update (a, 0, word64ToWord32 (Word64.>> (w, 0w32)));
-            PackWord32Big.update (a, 1, word64ToWord32 w);
+            PackWord32Big.update (a, 0, Word32.toLarge (word64ToWord32 (Word64.>> (w, 0w32))));
+            PackWord32Big.update (a, 1, Word32.toLarge (word64ToWord32 w));
             Bytestring.fromWord8Vector (Word8Array.vector a)
          end
 
@@ -111,8 +111,8 @@ structure ConvertWord : CONVERT_WORD =
          let
             val a = Word8Array.array (8, 0w0)
          in
-            PackWord32Little.update (a, 1, word64ToWord32 (Word64.>> (w, 0w32)));
-            PackWord32Little.update (a, 0, word64ToWord32 w);
+            PackWord32Little.update (a, 1, Word32.toLarge (word64ToWord32 (Word64.>> (w, 0w32))));
+            PackWord32Little.update (a, 0, Word32.toLarge (word64ToWord32 w));
             Bytestring.fromWord8Vector (Word8Array.vector a)
          end
          
@@ -123,7 +123,7 @@ structure ConvertWord : CONVERT_WORD =
          if Bytestring.size s <> 4 orelse Word8.> (Bytestring.sub (s, 0), 0wx7f) then
             raise ConvertWord
          else
-            word32ToWord31 (PackWord32Big.subVec (s, 0))
+            word32ToWord31 (Word32.fromLarge (PackWord32Big.subVec (s, 0)))
 
       fun bytesToWord31SB s = bytesToWord31B (Bytesubstring.string s)
 
@@ -131,7 +131,7 @@ structure ConvertWord : CONVERT_WORD =
          if Bytestring.size s <> 4 orelse Word8.> (Bytestring.sub (s, 3), 0wx7f) then
             raise ConvertWord
          else
-            word32ToWord31 (PackWord32Little.subVec (s, 0))
+            word32ToWord31 (Word32.fromLarge (PackWord32Little.subVec (s, 0)))
 
       fun bytesToWord31SL s = bytesToWord31L (Bytesubstring.string s)
 
@@ -139,7 +139,7 @@ structure ConvertWord : CONVERT_WORD =
          if Bytestring.size s <> 4 then
             raise ConvertWord
          else
-            PackWord32Big.subVec (s, 0)
+            Word32.fromLarge (PackWord32Big.subVec (s, 0))
 
       fun bytesToWord32SB s = bytesToWord32B (Bytesubstring.string s)
 
@@ -147,7 +147,7 @@ structure ConvertWord : CONVERT_WORD =
          if Bytestring.size s <> 4 then
             raise ConvertWord
          else
-            PackWord32Little.subVec (s, 0)
+            Word32.fromLarge (PackWord32Little.subVec (s, 0))
 
       fun bytesToWord32SL s = bytesToWord32L (Bytesubstring.string s)
 
@@ -155,8 +155,8 @@ structure ConvertWord : CONVERT_WORD =
          if Bytestring.size s <> 8 then
             raise ConvertWord
          else
-            Word64.orb (Word64.<< (word32ToWord64 (PackWord32Big.subVec (s, 0)), 0w32),
-                        word32ToWord64 (PackWord32Big.subVec (s, 1)))
+            Word64.orb (Word64.<< (word32ToWord64 (Word32.fromLarge (PackWord32Big.subVec (s, 0))), 0w32),
+                        word32ToWord64 (Word32.fromLarge (PackWord32Big.subVec (s, 1))))
 
       fun bytesToWord64SB s = bytesToWord64B (Bytesubstring.string s)        
 
@@ -164,8 +164,8 @@ structure ConvertWord : CONVERT_WORD =
          if Bytestring.size s <> 8 then
             raise ConvertWord
          else
-            Word64.orb (Word64.<< (word32ToWord64 (PackWord32Little.subVec (s, 1)), 0w32),
-                        word32ToWord64 (PackWord32Little.subVec (s, 0)))
+            Word64.orb (Word64.<< (word32ToWord64 (Word32.fromLarge (PackWord32Little.subVec (s, 1))), 0w32),
+                        word32ToWord64 (Word32.fromLarge (PackWord32Little.subVec (s, 0))))
 
       fun bytesToWord64SL s = bytesToWord64L (Bytesubstring.string s)        
 
@@ -200,13 +200,13 @@ structure ConvertWord : CONVERT_WORD =
       val wordLgToWord = Word.fromLarge
       val wordLgToWord8 = Word8.fromLarge
       val wordLgToWord31 = Word31.fromLarge
-      fun wordLgToWord32 w = w
-      fun wordLgToWord32X w = w
-      val wordLgToWord64 = word32ToWord64
-      val wordLgToWord64X = word32ToWord64X
+      fun wordLgToWord32 w = Word32.fromLarge w
+      fun wordLgToWord32X w = Word32.fromLarge w
+      val wordLgToWord64 = word32ToWord64 o Word32.fromLarge
+      val wordLgToWord64X = word32ToWord64X o Word32.fromLarge
       val wordLgToIntInf = LargeWord.toLargeInt
-      val wordLgToBytesB = word32ToBytesB
-      val wordLgToBytesL = word32ToBytesL
+      val wordLgToBytesB = word32ToBytesB o Word32.fromLarge
+      val wordLgToBytesL = word32ToBytesL o Word32.fromLarge
 
       val wordToWordLg = Word.toLarge
       val word8ToWordLg = Word8.toLarge
@@ -215,12 +215,12 @@ structure ConvertWord : CONVERT_WORD =
       val word31ToWordLgX = Word31.toLargeX
       val word32ToWordLg = Word32.toLarge
       val word32ToWordLgX = Word32.toLargeX
-      val word64ToWordLg = word64ToWord32
-      val word64ToWordLgX = word64ToWord32
+      val word64ToWordLg = Word32.toLarge o word64ToWord32
+      val word64ToWordLgX = Word32.toLarge o word64ToWord32
       val intInfToWordLg = LargeWord.fromLargeInt
-      val bytesToWordLgB = bytesToWord32B
-      val bytesToWordLgSB = bytesToWord32SB
-      val bytesToWordLgL = bytesToWord32L
-      val bytesToWordLgSL = bytesToWord32SL
+      val bytesToWordLgB = Word32.toLarge o bytesToWord32B
+      val bytesToWordLgSB = Word32.toLarge o bytesToWord32SB
+      val bytesToWordLgL = Word32.toLarge o bytesToWord32L
+      val bytesToWordLgSL = Word32.toLarge o bytesToWord32SL
 
    end

--- a/convert-word-nj.sml
+++ b/convert-word-nj.sml
@@ -5,7 +5,6 @@ structure ConvertWord : CONVERT_WORD =
       type word = Word.word
       type wordlg = LargeWord.word
       type word8 = Word8.word
-      type word31 = Word31.word
       type word32 = Word32.word
       type word64 = Word64.word
 
@@ -15,8 +14,6 @@ structure ConvertWord : CONVERT_WORD =
 
       (* This stuff all depends on the size of LargeWord. *)
 
-      fun word8ToWord31 w = Word31.fromLarge (Word8.toLarge w)
-      fun word8ToWord31X w = Word31.fromLarge (Word8.toLargeX w)
       val word8ToWord32 = Word32.fromLarge o Word8.toLarge
       val word8ToWord32X = Word32.fromLarge o Word8.toLargeX
       fun word8ToWord64 w = Word64.fromInt (Word8.toInt w)
@@ -25,53 +22,31 @@ structure ConvertWord : CONVERT_WORD =
       fun word8ToWord64X w =
          let
             val x = word8ToWord64 w
-            
+
             open Word64
          in
             orb (x, andb (0wxffffffffffffff00, xorb (>> (andb (x, 0wx80), 0w7), 0w1) - 0w1))
          end
 
-      fun word31ToWord8 w = Word8.fromLarge (Word31.toLarge w)
-      val word31ToWord32 = Word32.fromLarge o Word31.toLarge
-      val word31ToWord32X = Word32.fromLarge o Word31.toLargeX
-      val word31ToIntInf = Word31.toLargeInt
-
-      fun word31ToWord64 w = 
-         (* probably inefficient, since LargeInt is infinite precision *)
-         Word64.fromLargeInt (Word31.toLargeInt w)
-
-      fun word31ToWord64X w =
-         let
-            val x = word31ToWord64 w
-            
-            open Word64
-         in
-            orb (x, andb (0wxFFFFFFFF80000000, xorb (>> (andb (x, 0wx40000000), 0w30), 0w1) - 0w1))
-         end
-
-
       val word32ToWord8 = Word8.fromLarge o Word32.toLarge
-      val word32ToWord31 = Word31.fromLarge o Word32.toLarge
       fun word32ToWord64 w = Word64.fromLargeInt (Word32.toLargeInt w)
       val word32ToIntInf = Word32.toLargeInt
 
       fun word32ToWord64X w =
          let
             val x = word32ToWord64 w
-            
+
             open Word64
          in
             orb (x, andb (0wxFFFFFFFF00000000, xorb (>> (andb (x, 0wx80000000), 0w31), 0w1) - 0w1))
          end
 
       fun word64ToWord8 w = Word8.fromInt (Word64.toInt (Word64.andb (w, 0wxff)))
-      fun word64ToWord31 w = Word31.fromLargeInt (Word64.toLargeInt (Word64.andb (w, 0wx7fffffff)))
       fun word64ToWord32 w = Word32.fromLargeInt (Word64.toLargeInt (Word64.andb (w, 0wxffffffff)))
       val word64ToIntInf = Word64.toLargeInt
 
 
       val intInfToWord8 = Word8.fromLargeInt
-      val intInfToWord31 = Word31.fromLargeInt
       val intInfToWord32 = Word32.fromLargeInt
       val intInfToWord64 = Word64.fromLargeInt
 
@@ -92,12 +67,6 @@ structure ConvertWord : CONVERT_WORD =
             Bytestring.fromWord8Vector (Word8Array.vector a)
          end
 
-      fun word31ToBytesB w =
-         word32ToBytesB (word31ToWord32 w)
-
-      fun word31ToBytesL w =
-         word32ToBytesL (word31ToWord32 w)
-
       fun word64ToBytesB w =
          let
             val a = Word8Array.array (8, 0w0)
@@ -115,25 +84,9 @@ structure ConvertWord : CONVERT_WORD =
             PackWord32Little.update (a, 0, Word32.toLarge (word64ToWord32 w));
             Bytestring.fromWord8Vector (Word8Array.vector a)
          end
-         
+
 
       exception ConvertWord
-
-      fun bytesToWord31B s =
-         if Bytestring.size s <> 4 orelse Word8.> (Bytestring.sub (s, 0), 0wx7f) then
-            raise ConvertWord
-         else
-            word32ToWord31 (Word32.fromLarge (PackWord32Big.subVec (s, 0)))
-
-      fun bytesToWord31SB s = bytesToWord31B (Bytesubstring.string s)
-
-      fun bytesToWord31L s =
-         if Bytestring.size s <> 4 orelse Word8.> (Bytestring.sub (s, 3), 0wx7f) then
-            raise ConvertWord
-         else
-            word32ToWord31 (Word32.fromLarge (PackWord32Little.subVec (s, 0)))
-
-      fun bytesToWord31SL s = bytesToWord31L (Bytesubstring.string s)
 
       fun bytesToWord32B s =
          if Bytestring.size s <> 4 then
@@ -158,7 +111,7 @@ structure ConvertWord : CONVERT_WORD =
             Word64.orb (Word64.<< (word32ToWord64 (Word32.fromLarge (PackWord32Big.subVec (s, 0))), 0w32),
                         word32ToWord64 (Word32.fromLarge (PackWord32Big.subVec (s, 1))))
 
-      fun bytesToWord64SB s = bytesToWord64B (Bytesubstring.string s)        
+      fun bytesToWord64SB s = bytesToWord64B (Bytesubstring.string s)
 
       fun bytesToWord64L s =
          if Bytestring.size s <> 8 then
@@ -167,39 +120,47 @@ structure ConvertWord : CONVERT_WORD =
             Word64.orb (Word64.<< (word32ToWord64 (Word32.fromLarge (PackWord32Little.subVec (s, 1))), 0w32),
                         word32ToWord64 (Word32.fromLarge (PackWord32Little.subVec (s, 0))))
 
-      fun bytesToWord64SL s = bytesToWord64L (Bytesubstring.string s)        
+      fun bytesToWord64SL s = bytesToWord64L (Bytesubstring.string s)
 
 
 
       (* This stuff depends on the size of Word/LargeWord. *)
 
-      val wordToWord8 = word31ToWord8
-      fun wordToWord31 w = w
-      val wordToWord32 = word31ToWord32
-      val wordToWord32X = word31ToWord32X
-      val wordToWord64 = word31ToWord64
-      val wordToWord64X = word31ToWord64X
-      val wordToIntInf = word31ToIntInf
-      val wordToBytesB = word31ToBytesB
-      val wordToBytesL = word31ToBytesL
+      val wordToWord8 = Word8.fromLarge o Word.toLarge
+      val wordToWord32 = Word32.fromLarge o Word.toLarge
+      val wordToWord32X = Word32.fromLarge o Word.toLargeX
+      val wordToWord64 = Word64.fromLarge o Word.toLarge
+      val wordToWord64X = Word64.fromLarge o Word.toLargeX
+      val wordToIntInf = Word.toLargeInt
+      val wordToBytesB = word32ToBytesB o wordToWord32
+      val wordToBytesL = word32ToBytesL o wordToWord32
 
-      val word8ToWord = word8ToWord31
-      val word8ToWordX = word8ToWord31X
-      fun word31ToWord w = w
-      fun word31ToWordX w = w
-      val word32ToWord = word32ToWord31
-      val word32ToWordX = word32ToWord31
-      val word64ToWord = word64ToWord31
-      val word64ToWordX = word64ToWord31
-      val intInfToWord = intInfToWord31
-      val bytesToWordB = bytesToWord31B
-      val bytesToWordSB = bytesToWord31SB
-      val bytesToWordL = bytesToWord31L
-      val bytesToWordSL = bytesToWord31SL
+      val word8ToWord = Word.fromLarge o Word8.toLarge
+      val word8ToWordX = Word.fromLarge o Word8.toLargeX
+      val word32ToWord = Word.fromLarge o Word32.toLarge
+      val word32ToWordX = Word.fromLarge o Word32.toLargeX
+      val word64ToWord = Word.fromLarge o Word64.toLarge
+      val word64ToWordX = Word.fromLarge o Word64.toLargeX
+      val intInfToWord = Word.fromLargeInt
+
+      fun bytesToWordB s =
+         if Bytestring.size s <> 4 orelse Word8.> (Bytestring.sub (s, 0), 0wx7f) then
+            raise ConvertWord
+         else
+            Word.fromLarge (PackWord32Big.subVec (s, 0))
+
+      val bytesToWordSB = bytesToWordB o Bytesubstring.string
+
+      fun bytesToWordL s =
+         if Bytestring.size s <> 4 orelse Word8.> (Bytestring.sub (s, 3), 0wx7f) then
+            raise ConvertWord
+         else
+            Word.fromLarge (PackWord32Little.subVec (s, 0))
+
+      val bytesToWordSL = bytesToWordL o Bytesubstring.string
 
       val wordLgToWord = Word.fromLarge
       val wordLgToWord8 = Word8.fromLarge
-      val wordLgToWord31 = Word31.fromLarge
       fun wordLgToWord32 w = Word32.fromLarge w
       fun wordLgToWord32X w = Word32.fromLarge w
       val wordLgToWord64 = word32ToWord64 o Word32.fromLarge
@@ -211,8 +172,6 @@ structure ConvertWord : CONVERT_WORD =
       val wordToWordLg = Word.toLarge
       val word8ToWordLg = Word8.toLarge
       val word8ToWordLgX = Word8.toLargeX
-      val word31ToWordLg = Word31.toLarge
-      val word31ToWordLgX = Word31.toLargeX
       val word32ToWordLg = Word32.toLarge
       val word32ToWordLgX = Word32.toLargeX
       val word64ToWordLg = Word32.toLarge o word64ToWord32

--- a/convert-word.sig
+++ b/convert-word.sig
@@ -7,14 +7,12 @@ signature CONVERT_WORD =
       type wordlg = LargeWord.word       (* must be at least 31 bits *)
       type word8 = Word8.word
       type word32 = Word32.word          (* optional in the SML Basis, but required by CMLIB *)
-      
+
       (* optional words, set to unit if not supported *)
-      type word31
       type word64
 
       val wordToWordLg : word -> wordlg
       val wordToWord8 : word -> word8
-      val wordToWord31 : word -> word31
       val wordToWord32 : word -> word32
       val wordToWord32X : word -> word32
       val wordToWord64 : word -> word64
@@ -25,7 +23,6 @@ signature CONVERT_WORD =
 
       val wordLgToWord : wordlg -> word
       val wordLgToWord8 : wordlg -> word8
-      val wordLgToWord31 : wordlg -> word31
       val wordLgToWord32 : wordlg -> word32
       val wordLgToWord32X : wordlg -> word32
       val wordLgToWord64 : wordlg -> word64
@@ -38,33 +35,17 @@ signature CONVERT_WORD =
       val word8ToWordX : word8 -> word
       val word8ToWordLg : word8 -> wordlg
       val word8ToWordLgX : word8 -> wordlg
-      val word8ToWord31 : word8 -> word31
-      val word8ToWord31X : word8 -> word31
       val word8ToWord32 : word8 -> word32
       val word8ToWord32X : word8 -> word32
       val word8ToWord64 : word8 -> word64
       val word8ToWord64X : word8 -> word64
       val word8ToIntInf : word8 -> IntInf.int
 
-      val word31ToWord : word31 -> word
-      val word31ToWordX : word31 -> word
-      val word31ToWordLg : word31 -> wordlg
-      val word31ToWordLgX : word31 -> wordlg
-      val word31ToWord8 : word31 -> word8
-      val word31ToWord32 : word31 -> word32
-      val word31ToWord32X : word31 -> word32
-      val word31ToWord64 : word31 -> word64
-      val word31ToWord64X : word31 -> word64
-      val word31ToBytesB : word31 -> Bytestring.string
-      val word31ToBytesL : word31 -> Bytestring.string
-      val word31ToIntInf : word31 -> IntInf.int
-
       val word32ToWord : word32 -> word
       val word32ToWordX : word32 -> word
       val word32ToWordLg : word32 -> wordlg
       val word32ToWordLgX : word32 -> wordlg
       val word32ToWord8 : word32 -> word8
-      val word32ToWord31 : word32 -> word31
       val word32ToWord64 : word32 -> word64
       val word32ToWord64X : word32 -> word64
       val word32ToBytesB : word32 -> Bytestring.string
@@ -76,7 +57,6 @@ signature CONVERT_WORD =
       val word64ToWordLg : word64 -> wordlg
       val word64ToWordLgX : word64 -> wordlg
       val word64ToWord8 : word64 -> word8
-      val word64ToWord31 : word64 -> word31
       val word64ToWord32 : word64 -> word32
       val word64ToBytesB : word64 -> Bytestring.string
       val word64ToBytesL : word64 -> Bytestring.string
@@ -85,7 +65,6 @@ signature CONVERT_WORD =
       val intInfToWord : IntInf.int -> word
       val intInfToWordLg : IntInf.int -> wordlg
       val intInfToWord8 : IntInf.int -> word8
-      val intInfToWord31 : IntInf.int -> word31
       val intInfToWord32 : IntInf.int -> word32
       val intInfToWord64 : IntInf.int -> word64
 
@@ -94,8 +73,6 @@ signature CONVERT_WORD =
       val bytesToWordL : Bytestring.string -> word
       val bytesToWordLgB : Bytestring.string -> wordlg
       val bytesToWordLgL : Bytestring.string -> wordlg
-      val bytesToWord31B : Bytestring.string -> word31
-      val bytesToWord31L : Bytestring.string -> word31
       val bytesToWord32B : Bytestring.string -> word32
       val bytesToWord32L : Bytestring.string -> word32
       val bytesToWord64B : Bytestring.string -> word64
@@ -105,8 +82,6 @@ signature CONVERT_WORD =
       val bytesToWordSL : Bytesubstring.substring -> word
       val bytesToWordLgSB : Bytesubstring.substring -> wordlg
       val bytesToWordLgSL : Bytesubstring.substring -> wordlg
-      val bytesToWord31SB : Bytesubstring.substring -> word31
-      val bytesToWord31SL : Bytesubstring.substring -> word31
       val bytesToWord32SB : Bytesubstring.substring -> word32
       val bytesToWord32SL : Bytesubstring.substring -> word32
       val bytesToWord64SB : Bytesubstring.substring -> word64


### PR DESCRIPTION
Main changes:

* Updated `wordlg` from `Word32.word` to `LargeWord.word`
* Removed `word31` and `Word31` references and conversions
* Updated wordToX and XToWord conversions to use Word.fromXXX and Word.toXXX instead of Word31.fromXXX and Word31.toXXX

After making these changes, was able to compile cmlib using an 64-bit SML version built from source (using `config/install.sh -default 64`) in Windows Subsystem for Linux. Also tested using 32-bit native Windows SML version, and it works there, too.