### PR TITLE
Type annotate header as a B.byte

### DIFF
--- a/ec-der.sml
+++ b/ec-der.sml
@@ -80,7 +80,7 @@ functor EllipticCurveDERFun (structure EllipticCurve : ELLIPTIC_CURVE)
                 raise Invalid
            | SOME (x, y) =>
                 let
-                   val header =
+                   val header : B.byte =
                       if EC.parity (curve, pt) then
                          0wx03
                       else


### PR DESCRIPTION
I'm working on a [language server for Standard ML][1]. I'm very close to being able to analyze all of cmlib without errors. Right now I have only one: the type of a local binding `header` in `ec-der.sml` is inferred to be the wrong overloaded type (the default `word` type instead of `B.byte`).

This is because my implementation solves overloaded types per declaration (not structure level declaration, rather just `val` etc declarations). Since `val header` is its own declaration, it is resolved to the default type `word`, which then causes its later usage to type error.

Per the revised '97 Definition of Standard ML, section E, page 86, emphasis mine:

> Every overloaded constant and value identifier has among its types a default type, which is assigned to it, when the surrounding text does not resolve the overloading. For this purpose, the surrounding text is no larger than the smallest enclosing structure-level declaration; **an implementation may require that a smaller context determines the type.**

Indeed, my implementation does require this, in the sense that I would like to not complicate my implementation to solve overloads given any more program text than the smallest declaration, though I suppose SML/NJ and MLton both probably do this.

But in any case, this is a small change that allows strictly more current SML implementations to analyze cmlib.

[1]: https://github.com/azdavis/millet